### PR TITLE
CI Tuning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ cache:
   directories:
   - "$HOME/.cache"
 env:
-  - R_HOME=/usr/lib/R 
-  - LD_LIBRARY_PATH="$R_HOME/library/rJava/jri:$LD_LIBRARY_PATH"
+  - R_HOME=/usr/lib/R LD_LIBRARY_PATH="$R_HOME/library/rJava/jri:$LD_LIBRARY_PATH"
 before_install:
   - cp .travis.settings.xml $HOME/.m2/settings.xml
   - sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu trusty-cran35/'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_install:
   - sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu trusty-cran35/'
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
   - sudo apt-get update
-  - sudo apt-get install -y r-base r-base-dev r-base-core r-recommended
-  - sudo R CMD javareconf -n
+  - sudo apt-get install -y r-base r-base-dev r-base-core r-recommended r-cran-rjava
+  - sudo R CMD javareconf
   - sudo Rscript ./setup.R
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ cache:
   - "$HOME/.cache"
 env:
   - R_HOME=/usr/lib/R 
-  - LD_LIBRARY_PATH=$R_HOME/library/rJava/jri:$LD_LIBRARY_PATH
+  - LD_LIBRARY_PATH="$R_HOME/library/rJava/jri:$LD_LIBRARY_PATH"
 before_install:
   - cp .travis.settings.xml $HOME/.m2/settings.xml
   - sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu trusty-cran35/'
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
   - sudo apt-get update
   - sudo apt-get install -y r-base r-base-dev r-base-core r-recommended
-  - sudo R CMD javareconf -e
+#  - sudo R CMD javareconf -e
   - sudo Rscript ./setup.R
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
   directories:
   - "$HOME/.cache"
 env:
-  - R_HOME=/usr/lib/R LD_LIBRARY_PATH="$R_HOME/site-library/rJava/jri:$LD_LIBRARY_PATH"
+  - R_HOME=/usr/lib/R LD_LIBRARY_PATH="$JAVA_HOME/jre/lib:$R_HOME/site-library/rJava/jri:$LD_LIBRARY_PATH"
 before_install:
   - cp .travis.settings.xml $HOME/.m2/settings.xml
   - sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu trusty-cran35/'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran35/'
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
   - sudo apt update
-  - sudo apt install -y r-base r-base-core r-recommended
+  - sudo apt-get install -y r-base r-base-core r-recommended
 #  - sudo R CMD javareconf -e
   - sudo Rscript ./setup.R
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,16 @@ services:
 cache:
   directories:
   - "$HOME/.cache"
+env:
+  - R_HOME=/usr/lib/R 
+  - LD_LIBRARY_PATH=$R_HOME/library/rJava/jri:$LD_LIBRARY_PATH
 before_install:
   - cp .travis.settings.xml $HOME/.m2/settings.xml
   - sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu trusty-cran35/'
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
   - sudo apt-get update
   - sudo apt-get install -y r-base r-base-dev r-base-core r-recommended
-#  - sudo R CMD javareconf -e
+  - sudo R CMD javareconf -e
   - sudo Rscript ./setup.R
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,16 @@ cache:
   directories:
   - "$HOME/.cache"
 env:
-#  - R_HOME=/usr/local/lib/R LD_LIBRARY_PATH="$R_HOME/site-library/rJava/jri:$LD_LIBRARY_PATH"
+  - R_HOME=/usr/lib/R LD_LIBRARY_PATH="$R_HOME/library/rJava/jri:/usr/lib/R/site-library/rJava/jri:/usr/local/lib/R/site-library/rJava/jri:$LD_LIBRARY_PATH"
 before_install:
   - cp .travis.settings.xml $HOME/.m2/settings.xml
   - sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu trusty-cran35/'
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
   - sudo apt-get update
   - sudo apt-get install -y r-base r-base-dev r-base-core r-recommended r-cran-rjava
-  - echo $R_HOME
-  - cd $R_HOME && ls -al
-  - cd $R_HOME/site-library/ && ls -al
+  - cd /usr/lib/R/site-library/ && ls -al
+  - cd /usr/local/lib/R/site-library/ && ls -al
+  - cd /usr/lib/R/library/ && ls -al
   - sudo R CMD javareconf
   - sudo Rscript ./setup.R
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
   directories:
   - "$HOME/.cache"
 env:
-  - R_HOME=/usr/lib/R LD_LIBRARY_PATH="$R_HOME/library/rJava/jri:$LD_LIBRARY_PATH"
+  - R_HOME=/usr/local/lib/R LD_LIBRARY_PATH="$R_HOME/site-library/rJava/jri:$LD_LIBRARY_PATH"
 before_install:
   - cp .travis.settings.xml $HOME/.m2/settings.xml
   - sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu trusty-cran35/'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran35/'
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
   - sudo apt update
-  - sudo apt-get install -y r-base r-base-core r-recommended
+  - sudo apt-get install -y r-base r-base-dev r-base-core r-recommended
 #  - sudo R CMD javareconf -e
   - sudo Rscript ./setup.R
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ before_install:
   - sudo apt-get install -y r-base r-base-dev r-base-core r-recommended r-cran-rjava
   - sudo R CMD javareconf
   - sudo Rscript ./setup.R
-script: mvn test -B -DskipTests=true
+script: mvn test -B -DskipTests
 
 deploy:
   provider: script
-  script: "cp .travis.settings.xml $HOME/.m2/settings.xml && mvn deploy"
+  script: "cp .travis.settings.xml $HOME/.m2/settings.xml && mvn deploy -DskipTests"
   skip_cleanup: true
   on:
     all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,14 @@ cache:
   directories:
   - "$HOME/.cache"
 env:
-  - R_HOME=/usr/lib/R LD_LIBRARY_PATH="$R_HOME/library/rJava/jri:/usr/lib/R/site-library/rJava/jri:/usr/local/lib/R/site-library/rJava/jri:$LD_LIBRARY_PATH"
+  - R_HOME=/usr/lib/R LD_LIBRARY_PATH="$R_HOME/site-library/rJava/jri:$LD_LIBRARY_PATH"
 before_install:
   - cp .travis.settings.xml $HOME/.m2/settings.xml
   - sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu trusty-cran35/'
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
   - sudo apt-get update
   - sudo apt-get install -y r-base r-base-dev r-base-core r-recommended r-cran-rjava
-  - cd /usr/lib/R/site-library/ && ls -al
-  - cd /usr/local/lib/R/site-library/ && ls -al
-  - cd /usr/lib/R/library/ && ls -al
+  - ls -al /usr/lib/R/site-library/rJava/jri
   - sudo R CMD javareconf
   - sudo Rscript ./setup.R
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
   - sudo apt-get update
   - sudo apt-get install -y r-base r-base-dev r-base-core r-recommended
-#  - sudo R CMD javareconf -e
+  - sudo R CMD javareconf -n
   - sudo Rscript ./setup.R
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ before_install:
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
   - sudo apt-get update
   - sudo apt-get install -y r-base r-base-dev r-base-core r-recommended r-cran-rjava
+  - echo $R_HOME
+  - cd $R_HOME && ls -al cd ./site-library/ && ls -al
   - sudo R CMD javareconf
   - sudo Rscript ./setup.R
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
   directories:
   - "$HOME/.cache"
 env:
+# Unable to resolve the some libraries - JVM crash on tests
   - R_HOME=/usr/lib/R LD_LIBRARY_PATH="$JAVA_HOME/jre/lib:$R_HOME/site-library/rJava/jri:$LD_LIBRARY_PATH"
 before_install:
   - cp .travis.settings.xml $HOME/.m2/settings.xml
@@ -14,9 +15,9 @@ before_install:
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
   - sudo apt-get update
   - sudo apt-get install -y r-base r-base-dev r-base-core r-recommended r-cran-rjava
-  - ls -al /usr/lib/R/site-library/rJava/jri
   - sudo R CMD javareconf
   - sudo Rscript ./setup.R
+script: mvn test -B -DskipTests=true
 
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
   - "$HOME/.cache"
 before_install:
   - cp .travis.settings.xml $HOME/.m2/settings.xml
-  - sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran35/'
+  - sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu trusty-cran35/'
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
   - sudo apt-get update
   - sudo apt-get install -y r-base r-base-dev r-base-core r-recommended

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 language: java
 services:
@@ -9,7 +10,7 @@ before_install:
   - cp .travis.settings.xml $HOME/.m2/settings.xml
   - sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran35/'
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
-  - sudo apt update
+  - sudo apt-get update
   - sudo apt-get install -y r-base r-base-dev r-base-core r-recommended
 #  - sudo R CMD javareconf -e
   - sudo Rscript ./setup.R

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
   directories:
   - "$HOME/.cache"
 env:
-  - R_HOME=/usr/local/lib/R LD_LIBRARY_PATH="$R_HOME/site-library/rJava/jri:$LD_LIBRARY_PATH"
+#  - R_HOME=/usr/local/lib/R LD_LIBRARY_PATH="$R_HOME/site-library/rJava/jri:$LD_LIBRARY_PATH"
 before_install:
   - cp .travis.settings.xml $HOME/.m2/settings.xml
   - sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu trusty-cran35/'
@@ -15,7 +15,8 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -y r-base r-base-dev r-base-core r-recommended r-cran-rjava
   - echo $R_HOME
-  - cd $R_HOME && ls -al cd ./site-library/ && ls -al
+  - cd $R_HOME && ls -al
+  - cd $R_HOME/site-library/ && ls -al
   - sudo R CMD javareconf
   - sudo Rscript ./setup.R
 


### PR DESCRIPTION
Finally, we have to ignore tests on Travis CI. Because of some unexpected JVM crash during R starting. Probably, the problem may be solved by adding more libraries to the PATH or LD_LIBRARY_PATH.